### PR TITLE
Enhance layout with Bootstrap and add cart page

### DIFF
--- a/tortillas/admin.html
+++ b/tortillas/admin.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dashboard Admin</title>
   <link rel="stylesheet" href="assets/normalize.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="css/estilos.css">
 </head>
 <body data-dashboard="admin">
   <header>
-    <div class="container">
+    <div class="container d-flex align-items-center justify-content-between">
       <a href="index.html"><img src="imagenes_scrap/000001.jpg" alt="Logo Tortillas"></a>
       <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menú">☰</button>
       <nav>
@@ -23,7 +25,7 @@
         </ul>
       </nav>
       <input type="checkbox" id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-      <div class="cart"><a href="#" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
+      <div class="cart"><a href="carrito.html" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
     </div>
   </header>
 
@@ -38,6 +40,7 @@
   </footer>
 
   <script src="js/menu.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/theme.js" type="module"></script>
   <script type="module">
     import { createDashboard } from './js/dashboardFactory.js';

--- a/tortillas/cajero.html
+++ b/tortillas/cajero.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dashboard Cajero</title>
   <link rel="stylesheet" href="assets/normalize.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="css/estilos.css">
 </head>
 <body data-dashboard="cajero">
   <header>
-    <div class="container">
+    <div class="container d-flex align-items-center justify-content-between">
       <a href="index.html"><img src="imagenes_scrap/000001.jpg" alt="Logo Tortillas"></a>
       <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menú">☰</button>
       <nav>
@@ -23,7 +25,7 @@
         </ul>
       </nav>
       <input type="checkbox" id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-      <div class="cart"><a href="#" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
+      <div class="cart"><a href="carrito.html" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
     </div>
   </header>
 
@@ -38,6 +40,7 @@
   </footer>
 
   <script src="js/menu.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/theme.js" type="module"></script>
   <script type="module">
     import { createDashboard } from './js/dashboardFactory.js';

--- a/tortillas/carrito.html
+++ b/tortillas/carrito.html
@@ -2,11 +2,10 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tortillas Artesanales - Inicio</title>
+  <title>Carrito de Compras</title>
   <link rel="stylesheet" href="assets/normalize.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="css/estilos.css">
 </head>
@@ -30,22 +29,45 @@
     </div>
   </header>
 
-  <main class="container">
-    <section>
-      <h1>Bienvenido a Tortillas Artesanales</h1>
-      <p>Las mejores tortillas mexicanas hechas a mano.</p>
-    </section>
+  <main class="container py-4">
+    <h1 class="mb-4">Carrito</h1>
+    <div id="cart-items"></div>
+    <p id="cart-total" class="mt-3 fw-bold"></p>
   </main>
 
   <footer>
-    <div class="container">
+    <div class="container d-flex align-items-center justify-content-between">
       <p>Síguenos en redes sociales | Contacto: info@tortillas.com | Ubicación: México</p>
     </div>
   </footer>
 
   <script src="js/menu.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="js/theme.js" type="module"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="js/carrito.js"></script>
+  <script type="module">
+    import { carrito } from './js/carrito.js';
+    const itemsEl = document.getElementById('cart-items');
+    const totalEl = document.getElementById('cart-total');
+    function render() {
+      itemsEl.innerHTML = '';
+      carrito.toArray().forEach(p => {
+        const row = document.createElement('div');
+        row.className = 'd-flex justify-content-between align-items-center border-bottom py-2';
+        row.innerHTML = `<span>${p.name} x${p.qty}</span><span>$${p.price * p.qty}</span>`;
+        const rm = document.createElement('button');
+        rm.className = 'btn btn-sm btn-danger remove-item';
+        rm.innerHTML = '&times;';
+        rm.dataset.id = p.id;
+        rm.addEventListener('click', () => {
+          carrito.remove(p.id);
+          render();
+        });
+        row.appendChild(rm);
+        itemsEl.appendChild(row);
+      });
+      totalEl.textContent = 'Total: $' + carrito.calculateTotal();
+    }
+    document.addEventListener('DOMContentLoaded', render);
+  </script>
 </body>
 </html>

--- a/tortillas/contacto.html
+++ b/tortillas/contacto.html
@@ -11,7 +11,7 @@
 </head>
 <body>
   <header>
-    <div class="container">
+    <div class="container d-flex align-items-center justify-content-between">
       <a href="index.html"><img src="imagenes_scrap/000001.jpg" alt="Logo Tortillas"></a>
       <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menú">☰</button>
       <nav>
@@ -25,7 +25,7 @@
         </ul>
       </nav>
       <input type="checkbox" id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-      <div class="cart"><a href="#" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
+      <div class="cart"><a href="carrito.html" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
     </div>
   </header>
 

--- a/tortillas/css/estilos.css
+++ b/tortillas/css/estilos.css
@@ -52,6 +52,9 @@ header {
   align-items: center;
   background-color: var(--color-primary);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 
 header img {

--- a/tortillas/js/carrito.js
+++ b/tortillas/js/carrito.js
@@ -103,15 +103,21 @@ function updateCartCount() {
   if (countEl) countEl.textContent = carrito.size;
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function setupCart() {
   updateCartCount();
-  document.querySelectorAll('.add-cart').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const { id, name, price } = btn.dataset;
+  document.addEventListener('click', e => {
+    if (e.target.classList.contains('add-cart')) {
+      const { id, name, price } = e.target.dataset;
       carrito.add({ id, name, price: Number(price) });
       updateCartCount();
-    });
+    }
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setupCart);
+} else {
+  setupCart();
+}
 
 export { carrito };

--- a/tortillas/js/menu.js
+++ b/tortillas/js/menu.js
@@ -6,3 +6,11 @@ if (toggleBtn) {
     navList.classList.toggle('open');
   });
 }
+
+if (navList) {
+  navList.addEventListener('click', e => {
+    if (e.target.tagName === 'A') {
+      navList.classList.remove('open');
+    }
+  });
+}

--- a/tortillas/nosotros.html
+++ b/tortillas/nosotros.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tortillas Artesanales - Nosotros</title>
   <link rel="stylesheet" href="assets/normalize.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="css/estilos.css">
 </head>
 <body>
   <header>
-    <div class="container">
+    <div class="container d-flex align-items-center justify-content-between">
       <a href="index.html"><img src="imagenes_scrap/000001.jpg" alt="Logo Tortillas"></a>
       <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menú">☰</button>
       <nav>
@@ -23,7 +25,7 @@
         </ul>
       </nav>
       <input type="checkbox" id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-      <div class="cart"><a href="#" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
+      <div class="cart"><a href="carrito.html" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
     </div>
   </header>
 
@@ -39,6 +41,7 @@
   </footer>
 
   <script src="js/menu.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/theme.js" type="module"></script>
   <script type="module" src="js/carrito.js"></script>
 </body>

--- a/tortillas/perfil.html
+++ b/tortillas/perfil.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Perfil de Cliente</title>
   <link rel="stylesheet" href="assets/normalize.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="css/estilos.css">
 </head>
 <body>
   <header>
-    <div class="container">
+    <div class="container d-flex align-items-center justify-content-between">
       <a href="index.html"><img src="imagenes_scrap/000001.jpg" alt="Logo Tortillas"></a>
       <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menú">☰</button>
       <nav>
@@ -23,7 +25,7 @@
         </ul>
       </nav>
       <input type="checkbox" id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-      <div class="cart"><a href="#" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
+      <div class="cart"><a href="carrito.html" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
     </div>
   </header>
 
@@ -38,6 +40,7 @@
   </footer>
 
   <script src="js/menu.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/theme.js" type="module"></script>
   <script type="module" src="js/perfil.js"></script>
   <script type="module" src="js/carrito.js"></script>

--- a/tortillas/productos.html
+++ b/tortillas/productos.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tortillas Artesanales - Productos</title>
   <link rel="stylesheet" href="assets/normalize.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="css/estilos.css">
 </head>
 <body>
   <header>
-    <div class="container">
+    <div class="container d-flex align-items-center justify-content-between">
       <a href="index.html"><img src="imagenes_scrap/000001.jpg" alt="Logo Tortillas"></a>
       <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menú">☰</button>
       <nav>
@@ -23,7 +25,7 @@
         </ul>
       </nav>
       <input type="checkbox" id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-      <div class="cart"><a href="#" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
+      <div class="cart"><a href="carrito.html" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
     </div>
   </header>
 
@@ -82,6 +84,7 @@
   </footer>
 
   <script src="js/menu.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/theme.js" type="module"></script>
   <script type="module" src="js/carrito.js"></script>
 </body>

--- a/tortillas/repartidor.html
+++ b/tortillas/repartidor.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dashboard Repartidor</title>
   <link rel="stylesheet" href="assets/normalize.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="css/estilos.css">
 </head>
 <body data-dashboard="repartidor">
   <header>
-    <div class="container">
+    <div class="container d-flex align-items-center justify-content-between">
       <a href="index.html"><img src="imagenes_scrap/000001.jpg" alt="Logo Tortillas"></a>
       <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menú">☰</button>
       <nav>
@@ -23,7 +25,7 @@
         </ul>
       </nav>
       <input type="checkbox" id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-      <div class="cart"><a href="#" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
+      <div class="cart"><a href="carrito.html" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
     </div>
   </header>
 
@@ -38,6 +40,7 @@
   </footer>
 
   <script src="js/menu.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/theme.js" type="module"></script>
   <script type="module">
     import { createDashboard } from './js/dashboardFactory.js';

--- a/tortillas/ubicaciones.html
+++ b/tortillas/ubicaciones.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tortillas Artesanales - Ubicaciones</title>
   <link rel="stylesheet" href="assets/normalize.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="stylesheet" href="css/estilos.css">
 </head>
 <body>
   <header>
-    <div class="container">
+    <div class="container d-flex align-items-center justify-content-between">
       <a href="index.html"><img src="imagenes_scrap/000001.jpg" alt="Logo Tortillas"></a>
       <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menú">☰</button>
       <nav>
@@ -23,7 +25,7 @@
         </ul>
       </nav>
       <input type="checkbox" id="theme-toggle" class="theme-toggle" aria-label="Cambiar tema">
-      <div class="cart"><a href="#" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
+      <div class="cart"><a href="carrito.html" id="cart-link">Carrito (<span id="cart-count">0</span>)</a></div>
     </div>
   </header>
 
@@ -40,6 +42,7 @@
   </footer>
 
   <script src="js/menu.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/theme.js" type="module"></script>
   <script type="module" src="js/carrito.js"></script>
   <script type="module" src="js/map.js"></script>


### PR DESCRIPTION
## Summary
- add sticky header for easier navigation
- close mobile menu when link is clicked
- include Bootstrap and icons on every page
- create `carrito.html` to display cart contents
- link cart button to the new page
- fix cart button listeners so items add correctly

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6865dd88740c8325a58dc3f8dc8b5e69