### PR TITLE
Fix front-end cart initialization

### DIFF
--- a/tortillas/js/carrito.js
+++ b/tortillas/js/carrito.js
@@ -147,13 +147,6 @@ if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', initCarrito);
 } else {
   initCarrito();
-  });
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', setupCart);
-} else {
-  setupCart();
 }
 
 window.carrito = carrito;


### PR DESCRIPTION
## Summary
- clean up `carrito.js` to remove leftover module code
- ensure cart setup runs when the page loads

## Testing
- `node --check tortillas/js/carrito.js`

------
https://chatgpt.com/codex/tasks/task_e_6865e5a7ae648325a980ff478f30ab6d