### PR TITLE
Fix offline order history

### DIFF
--- a/tortillas/carrito.html
+++ b/tortillas/carrito.html
@@ -33,6 +33,7 @@
     <h1 class="mb-4">Carrito</h1>
     <div id="cart-items"></div>
     <p id="cart-total" class="mt-3 fw-bold"></p>
+    <button id="checkout-btn" class="btn btn-primary mt-3">Realizar pedido</button>
   </main>
 
   <footer>

--- a/tortillas/js/carrito.js
+++ b/tortillas/js/carrito.js
@@ -138,22 +138,30 @@ function renderCartPage() {
   totalEl.textContent = 'Total: $' + carrito.calculateTotal();
 }
 
+function placeOrder() {
+  if (!carrito.size) return;
+  const historial = JSON.parse(localStorage.getItem('historialPedidos')) || [];
+  const detalle = carrito.toArray().map(p => `${p.name} x${p.qty}`).join(', ');
+  historial.push({ detalle, fecha: new Date().toISOString() });
+  localStorage.setItem('historialPedidos', JSON.stringify(historial));
+  carrito.head = carrito.tail = null;
+  carrito.size = 0;
+  carrito.save();
+  renderCartPage();
+  updateCartCount();
+}
+
 function initCarrito() {
   setupCart();
   renderCartPage();
+  const btn = document.getElementById('checkout-btn');
+  if (btn) btn.addEventListener('click', placeOrder);
 }
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', initCarrito);
 } else {
   initCarrito();
-  });
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', setupCart);
-} else {
-  setupCart();
 }
 
 window.carrito = carrito;

--- a/tortillas/js/perfil.js
+++ b/tortillas/js/perfil.js
@@ -2,13 +2,22 @@
  * Carga historial de pedidos para el perfil de usuario.
  * @module perfil
  */
-async function loadOrders() {
+function loadOrders() {
   const container = document.getElementById('orders');
   if (!container) return;
-  const res = await fetch('https://jsonplaceholder.typicode.com/posts?userId=1');
-  const orders = await res.json();
-  container.innerHTML = '<h2>Historial de pedidos</h2>' +
-    '<ul>' + orders.slice(0,5).map(o => `<li>Pedido #${o.id}: ${o.title}</li>`).join('') + '</ul>';
+  const orders = JSON.parse(localStorage.getItem('historialPedidos')) || [];
+  if (!orders.length) {
+    container.textContent = 'No hay pedidos en tu historial.';
+    return;
+  }
+  const list = document.createElement('ul');
+  orders.forEach((o, i) => {
+    const li = document.createElement('li');
+    li.textContent = `Pedido #${i + 1}: ${o.detalle}`;
+    list.appendChild(li);
+  });
+  container.innerHTML = '<h2>Historial de pedidos</h2>';
+  container.appendChild(list);
 }
 
 document.addEventListener('DOMContentLoaded', loadOrders);


### PR DESCRIPTION
## Summary
- store placed orders in `localStorage`
- display saved orders on profile page
- add checkout button to cart page

## Testing
- `node --check tortillas/js/carrito.js`
- `node --check tortillas/js/perfil.js`


------
https://chatgpt.com/codex/tasks/task_e_6865e5a7ae648325a980ff478f30ab6d